### PR TITLE
fix: Create & AutoFill button too wide in german

### DIFF
--- a/iOS/Shared/Localization/Localizable.xcstrings
+++ b/iOS/Shared/Localization/Localizable.xcstrings
@@ -38073,7 +38073,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Erstellen und automatisch ausfüllen"
+            "value" : "Erstellen & ausfüllen"
           }
         },
         "el" : {


### PR DESCRIPTION
Fixes an issue with the create & autofill button in the german localization. The text is too long, that causes the button to be too long and makes other buttons unusable. If you open the screen you are stuck since the close button isnt accessible. The only way to exit is to close the app in which you opened the screen.

![IMG_9913](https://github.com/user-attachments/assets/bbb3918a-3a97-4e2d-9738-5d050ffadee1)
